### PR TITLE
Clean up empty arrays

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,7 @@
           <includeConstructors>true</includeConstructors>
           <includeDynamicBuilders>true</includeDynamicBuilders>
           <includeAdditionalProperties>false</includeAdditionalProperties>
+          <inclusionLevel>NON_EMPTY</inclusionLevel>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
Removes emtpy arrays from the json parsing. Makes for a cleaner object