### PR TITLE
Use acceptedName when we match an a synonym

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.5</version>
+    <version>3.4.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>
@@ -24,6 +24,7 @@
     <gbif-name-parser-v1.version>3.10.2-SNAPSHOT</gbif-name-parser-v1.version>
     <gbif-common-ws.version>1.28-SNAPSHOT</gbif-common-ws.version>
     <lucene.version>9.9.1</lucene.version>
+    <ok-http.version>4.12.0</ok-http.version>
     <amazon.awssdk.version>2.29.6</amazon.awssdk.version>
     <commons-compress.version>1.27.1</commons-compress.version>
     <commons-io.version>2.17.0</commons-io.version>
@@ -168,7 +169,6 @@
       <artifactId>commons-compress</artifactId>
       <version>${commons-compress.version}</version>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
@@ -216,6 +216,7 @@
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver</artifactId>
+      <version>${ok-http.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/eu/dissco/nusearch/service/DigitalSpecimenMatchingServiceTest.java
+++ b/src/test/java/eu/dissco/nusearch/service/DigitalSpecimenMatchingServiceTest.java
@@ -159,7 +159,7 @@ class DigitalSpecimenMatchingServiceTest {
 
   private DigitalSpecimen expectedDigitalSpecimen() {
     DigitalSpecimen digitalSpecimen = new DigitalSpecimen();
-    digitalSpecimen.setOdsSpecimenName("Aa brevis Schltr.");
+    digitalSpecimen.setOdsSpecimenName("Myrosmodes brevis (Schltr.) Garay");
     digitalSpecimen.setOdsNormalisedPhysicalSpecimenID(NORMALISED_PHYSICAL_SPECIMEN_ID);
     digitalSpecimen.setOdsOrganisationID(INSTITUTION_ID);
     digitalSpecimen.setOdsTopicDiscipline(OdsTopicDiscipline.BOTANY);
@@ -169,11 +169,11 @@ class DigitalSpecimenMatchingServiceTest {
             .withDwcVerbatimIdentification("Aa brevis")
             .withOdsHasTaxonIdentifications(List.of(
                 new TaxonIdentification()
-                    .withId("https://www.catalogueoflife.org/data/taxon/7Q8L8")
-                    .withDwcTaxonID("https://www.catalogueoflife.org/data/taxon/7Q8L8")
-                    .withDwcScientificName("Aa brevis Schltr.")
-                    .withOdsScientificNameHTMLLabel("<i>Aa brevis</i> Schltr.")
-                    .withDwcScientificNameAuthorship("Schltr.")
+                    .withId("https://www.catalogueoflife.org/data/taxon/73SWK")
+                    .withDwcTaxonID("https://www.catalogueoflife.org/data/taxon/73SWK")
+                    .withDwcScientificName("Myrosmodes brevis (Schltr.) Garay")
+                    .withOdsScientificNameHTMLLabel("<i>Myrosmodes brevis</i> (Schltr.) Garay")
+                    .withDwcScientificNameAuthorship("(Schltr.) Garay")
                     .withDwcTaxonRank("SPECIES")
                     .withDwcKingdom("Plantae")
                     .withDwcPhylum("Tracheophyta")
@@ -183,19 +183,17 @@ class DigitalSpecimenMatchingServiceTest {
                     .withDwcGenus("Myrosmodes Rchb.f.")
                     .withOdsGenusHTMLLabel("<i>Myrosmodes</i> Rchb.f.")
                     .withDwcSpecificEpithet("brevis")
-                    .withDwcTaxonomicStatus("SYNONYM")
-                    .withDwcAcceptedNameUsage("Myrosmodes brevis (Schltr.) Garay")
-                    .withDwcAcceptedNameUsageID("73SWK")
+                    .withDwcTaxonomicStatus("ACCEPTED")
                     .withDwcGenericName("Aa")
             ))));
     digitalSpecimen.setOdsHasEntityRelationships(
         List.of(new EntityRelationship()
             .withType("ods:EntityRelationship")
             .withDwcRelationshipEstablishedDate(Date.from(DATE))
-            .withDwcRelatedResourceID("7Q8L8")
+            .withDwcRelatedResourceID("73SWK")
             .withDwcRelationshipOfResource("hasColID")
             .withOdsRelatedResourceURI(
-                URI.create("https://www.catalogueoflife.org/data/taxon/7Q8L8"))
+                URI.create("https://www.catalogueoflife.org/data/taxon/73SWK"))
             .withOdsHasAgents(List.of(new Agent().withType(SCHEMA_SOFTWARE_APPLICATION)
                 .withId("https://hdl.handle.net/TEST/123-123-123")
                 .withSchemaName("dissco-nusearch-service")


### PR DESCRIPTION
Use the acceptedName when we match on a synonym

When speciesName is not present check if accepteNameUsage is present in the original data and use it as alternative