### PR TITLE
Deduplicate ER's

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco</groupId>


### PR DESCRIPTION
Deduplicate the ER when multiple identification or taxon identification have matched against the same ColID. 
The resourceURI and resourceID can be seen as primary key for the entity relationships so should be unique.

https://naturalis.atlassian.net/browse/DD-1660